### PR TITLE
Fixed #1: The game stops working when the board is full

### DIFF
--- a/lib/managers/board.dart
+++ b/lib/managers/board.dart
@@ -137,14 +137,15 @@ class BoardManager extends StateNotifier<Board> {
   }
 
   // Generates tiles at random place on the board
-  Tile random(List<int> indexes) {
-    var i = 0;
-    var rng = Random();
-    do {
-      i = rng.nextInt(16);
-    } while (indexes.contains(i));
+  final rand = Random();
 
-    return Tile(const Uuid().v4(), 2, i);
+  /// Generates tiles at random place on the board.
+  /// Avoids occupied tiles.
+  Tile random(List<int> indexes) {
+    final candidates = Iterable.generate(16, (i) => i).toList();
+    candidates.removeWhere((i) => indexes.contains(i));
+    final index = candidates[rand.nextInt(candidates.length)];
+    return Tile(const Uuid().v4(), 2, index);
   }
 
   //Merge tiles
@@ -183,8 +184,9 @@ class BoardManager extends StateNotifier<Board> {
       indexes.add(tiles.last.index);
     }
 
-    //If tiles got moved then generate a new tile at random position of the available positions on the board.
-    if (tilesMoved) {
+    // If tiles got moved then generate a new tile at random position of the available positions on the board.
+    // If all tiles are occupied, then don't generate.
+    if (tilesMoved && indexes.length < 16) {
       tiles.add(random(indexes));
     }
     state = state.copyWith(score: score, tiles: tiles);


### PR DESCRIPTION
After inspecting the code, I found this function was the cause.
https://github.com/angjelkom/flutter_2048/blob/ca1c660f5e737ee51fb4259130b08c7677c62433/lib/managers/board.dart#L140-L148
The loop is endless when the `indexes` gets all 16 numbers.
And based on this algorithm, the probability of generating tiles at each location is not.